### PR TITLE
Provide credit card info to Refund call

### DIFF
--- a/payment_transactions.go
+++ b/payment_transactions.go
@@ -54,6 +54,9 @@ func (tranx NewTransaction) Refund() (*TransactionResponse, error) {
 		TransactionType: "refundTransaction",
 		Amount:          tranx.Amount,
 		RefTransId:      tranx.RefTransId,
+		Payment: &Payment{
+			CreditCard: tranx.CreditCard,
+		},
 	}
 	response, err := SendTransactionRequest(new)
 	return response, err


### PR DESCRIPTION
The Refund call is currently nonfunctional because it does not provide the credit card information from the transaction to Authorize.Net's API. This is just a quick PR to fix that.