### PR TITLE
Sequence change for billTo in case of create customer profile

### DIFF
--- a/customer_profile.go
+++ b/customer_profile.go
@@ -358,8 +358,8 @@ type Profile struct {
 
 type PaymentProfiles struct {
 	CustomerType string  `json:"customerType,omitempty"`
-	Payment      Payment `json:"payment,omitempty"`
 	BillTo       *BillTo `json:"billTo,omitempty"`
+	Payment      Payment `json:"payment,omitempty"`
 	PaymentId    string  `json:"paymentProfileId,omitempty"`
 }
 


### PR DESCRIPTION
Hi,

   When we save customer profile its gives error like "The element 'paymentProfiles' in namespace 'AnetApi/xml/v1/schema/AnetApiSchema.xsd' has invalid child element 'billTo' in namespace 'AnetApi/xml/v1/schema/AnetApiSchema.xsd'. List of possible elements expected: 'driversLicense, taxId, defaultPaymentProfile' in namespace 'AnetApi/xml/v1/schema/AnetApiSchema.xsd'"

To solve it I have to basically change the sequence. You can merge the pull request, if you like the changes as it will resolve issue for saving customer profile.