### PR TITLE
updated struct GetTransactionListResponse

### DIFF
--- a/transaction_reporting.go
+++ b/transaction_reporting.go
@@ -57,11 +57,11 @@ func (r UnsettledTransactionListResponse) List() []Transaction {
 }
 
 func (r *GetTransactionListResponse) List() []Transaction {
-	return r.GetTransactionList.Transactions.Transaction
+	return r.Transactions
 }
 
 func (r *GetTransactionListResponse) Count() int {
-	return r.GetTransactionList.TotalNumInResultSet
+	return r.TotalNumInResultSet
 }
 
 func (r Range) Transactions() (*GetTransactionListResponse, error) {
@@ -77,7 +77,7 @@ func (r Range) Transactions() (*GetTransactionListResponse, error) {
 	}
 	response, err := SendRequest(jsoned)
 	var dat GetTransactionListResponse
-	json.Unmarshal(response, &dat)
+	err = json.Unmarshal(response, &dat)
 	return &dat, err
 }
 
@@ -169,16 +169,14 @@ type GetTransactionList struct {
 }
 
 type GetTransactionListResponse struct {
-	GetTransactionList struct {
-		MessagesResponse
-		Transactions        Transactions `json:"transactions"`
-		TotalNumInResultSet int          `json:"totalNumInResultSet"`
-	} `json:"getTransactionListResponse"`
+	MessagesResponse
+	Transactions        []Transaction `json:"transactions"`
+	TotalNumInResultSet int           `json:"totalNumInResultSet"`
 }
 
-type Transactions struct {
-	Transaction []Transaction `json:"transaction"`
-}
+//type Transactions struct {
+//	Transaction []Transaction `json:"transaction"`
+//}
 
 type Transaction struct {
 	TransID           string  `json:"transId"`

--- a/transaction_reporting.go
+++ b/transaction_reporting.go
@@ -214,6 +214,8 @@ type TransactionDetailsResponse struct {
 }
 
 type FullTransaction struct {
+	//artificially introduced. Never filled by AuthNet
+	PaymentType               string
 	TransID                   string    `json:"transId"`
 	SubmitTimeUTC             time.Time `json:"submitTimeUTC"`
 	SubmitTimeLocal           string    `json:"submitTimeLocal"`
@@ -232,7 +234,8 @@ type FullTransaction struct {
 		SettlementState              string    `json:"settlementState"`
 	} `json:"batch"`
 	Order struct {
-		InvoiceNumber string `json:"invoiceNumber"`
+		InvoiceNumber      string `json:"invoiceNumber"`
+		InvoiceDescription string `json:"description"`
 	} `json:"order"`
 	RequestedAmountSpecified         bool    `json:"requestedAmountSpecified"`
 	AuthAmount                       float64 `json:"authAmount"`
@@ -247,10 +250,15 @@ type FullTransaction struct {
 			RoutingNumber        string      `json:"routingNumber"`
 			AccountNumber        string      `json:"accountNumber"`
 			NameOnAccount        string      `json:"nameOnAccount"`
-			EcheckType           int         `json:"echeckType"`
+			EcheckType           string      `json:"echeckType"`
 			EcheckTypeSpecified  bool        `json:"echeckTypeSpecified"`
 			BankName             interface{} `json:"bankName"`
-		} `json:"bankAccount"`
+		} `json:"bankAccount,omitempty"`
+		CreditCard struct {
+			CardNumber     string `json:"cardNumber"`
+			ExpirationDate string `json:"expirationDate"`
+			CardType       string `json:"cardType"`
+		} `json:"creditCard,omitempty"`
 	} `json:"payment"`
 	RecurringBilling          bool `json:"recurringBilling"`
 	RecurringBillingSpecified bool `json:"recurringBillingSpecified"`
@@ -261,6 +269,14 @@ type FullTransaction struct {
 		Code        string    `json:"code"`
 		Description string    `json:"description"`
 	} `json:"returnedItems"`
+	Customer struct {
+		Type  string `json:"type"`
+		Id    string `json:"id"`
+		Email string `json:"email"`
+	} `json:"customer"`
+	BillTo struct {
+		Company string `json:"company,omitempty"`
+	} `json:"billTo"`
 }
 
 type GetUnsettledBatchTransactionListRequest struct {


### PR DESCRIPTION
Please, check that if you have a chance:

If you go to:
https://developer.authorize.net/api/reference/index.html#transaction-reporting-get-transaction-list
the original **Response** has a section "getTransactionListResponse". But if you press a "Send" button this section (getTransactionListResponse) disappeared. This is what I've got trying to use your package: a response without "getTransactionListResponse".

So, these are changes which were made to get it working:

Updated "GetTransactionListResponse" to match current Auth.Net's "getTransactionListResponse".
A response from Auth.Net failed to unmarshal on line 80 in transaction_reporting.go

	err = json.Unmarshal(response, &dat)


Current Auth.Net response from 
https://developer.authorize.net/api/reference/index.html#transaction-reporting-get-transaction-list

{
    "transactions": [
        {
            "transId": "60106385658",
            "submitTimeUTC": "2018-07-26T14:38:17Z",
            "submitTimeLocal": "2018-07-26T07:38:17",
            "transactionStatus": "settledSuccessfully",
            "firstName": "Ellen",
            "lastName": "Johnson",
            "accountType": "MasterCard",
            "accountNumber": "XXXX0015",
            "settleAmount": 5,
            "marketType": "eCommerce",
            "product": "Card Not Present"
        }
    ],
    "totalNumInResultSet": 1,
    "messages": {
        "resultCode": "Ok",
        "message": [
            {
                "code": "I00001",
                "text": "Successful."
            }
        ]
    }
}
